### PR TITLE
feat: new-placeholder-sociais

### DIFF
--- a/src/components/FormAccount.tsx
+++ b/src/components/FormAccount.tsx
@@ -269,7 +269,7 @@ export default function FormAccount(props: FormAccountInterface) {
                 props.data.status?.pageStatus,
                 "border"
               )} border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-8/12 p-2.5`}
-              placeholder="@seuarroba"
+              placeholder="@seuusuário"
             />
           </div>
           <div className="flex gap-2">
@@ -317,7 +317,7 @@ export default function FormAccount(props: FormAccountInterface) {
                 props.data.status?.pageStatus,
                 "border"
               )} border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-8/12 p-2.5`}
-              placeholder="@seuarroba"
+              placeholder="@seuusuário"
             />
           </div>
           <div className="flex gap-2">
@@ -341,7 +341,7 @@ export default function FormAccount(props: FormAccountInterface) {
                 props.data.status?.pageStatus,
                 "border"
               )} border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-8/12 p-2.5`}
-              placeholder="@seuarroba"
+              placeholder="@seuusuário"
             />
           </div>
           <div className="flex gap-2">
@@ -365,7 +365,7 @@ export default function FormAccount(props: FormAccountInterface) {
                 props.data.status?.pageStatus,
                 "border"
               )} border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-8/12 p-2.5`}
-              placeholder="@seuarroba"
+              placeholder="@seuusuário"
             />
           </div>
           {/* <div className="flex gap-2">
@@ -389,7 +389,7 @@ export default function FormAccount(props: FormAccountInterface) {
                 props.data.status?.pageStatus,
                 "border"
               )} border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-8/12 p-2.5`}
-              placeholder="@seuarroba"
+              placeholder="@seuusuário"
             />
           </div> */}
           <div className="flex gap-2">


### PR DESCRIPTION
Novas mensagens de placeholder agora usam @seuusuário em vez de @seuarroba.

OLD:
![image](https://github.com/bolodissenoura/pixmeacoffee/assets/132523773/08e52b32-8566-4777-b54d-464676d27a71)

NEW:
![image](https://github.com/bolodissenoura/pixmeacoffee/assets/132523773/74c31603-d28e-4e2e-928f-9f951ea2fa9e)