### PR TITLE
fix broken link on "Saiba Mais"

### DIFF
--- a/src/components/PremiumCard.tsx
+++ b/src/components/PremiumCard.tsx
@@ -26,7 +26,7 @@ export default function PremiumCard() {
       </ul>
       <div className="flex flex-col">
         <Image src={"premium.svg"} alt="coffee" width={300} height={300} />
-        <Link href={"x.com/danillime"} target="_blank">
+        <Link href={"https://x.com/daniellimae"} target="_blank">
           <div className="flex gap-2 justify-center items-center bold text-primary-500">
             <p>Saiba mais</p>
             <span className="text-2xl">{">"}</span>


### PR DESCRIPTION
link's broken, it redirects to print below:

<img width="1320" alt="Screenshot 2024-02-01 at 2 54 34 PM" src="https://github.com/bolodissenoura/pixmeacoffee/assets/31139680/18016462-872f-46de-9c40-74e9cf15f483">



this should fix it.